### PR TITLE
use full path

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,8 +32,9 @@ class ContentInjector():
     # Get files in the injectFiles config that exist.
     def availableInjectFiles(self):
         files = []
-        for f in self.config['injectFiles']:
-            if os.path.isfile(os.path.join(mw.col.media.dir(), f)):
+        for filename in self.config['injectFiles']:
+            f = os.path.join(mw.col.media.dir(), filename)
+            if os.path.isfile(f):
                 files.append(f)
         return files
 


### PR DESCRIPTION
Fixes https://github.com/zacharied/anki-content-injector/issues/6
Fixes https://github.com/zacharied/anki-content-injector/issues/7
I'm on `Anki Versión ⁨2.1.58 (ab8b1465)⁩ Python 3.9.15 Qt 6.4.2 PyQt 6.4.0` and this makes it work again
inferior alternative solutions:
```py
        for f in self.config['injectFiles']:
            if os.path.isfile(os.path.join(mw.col.media.dir(), f)):
                #files.append(f)
                files.append(os.path.join(mw.col.media.dir(), f))
        return files
```
OR
```py
        for f in self.availableInjectFiles():
            #with open(f, 'r', encoding='utf-8') as injectFile:
            with open(os.path.join(mw.col.media.dir(), f), 'r', encoding='utf-8') as injectFile:
                _, ext = os.path.splitext(f)
```
availableInjectFiles takes the filename, checks the full path, then passes the filename*. 
injectContent tries to load the filename, then splits the filename to get the extension.
os.path.splitext does accept the full path, so either *availableInjectFiles should pass the full path OR injectContent should add the path.
It was unclear what f meant. Variable values:
filename `_global.html`
f `C:\Users\Khonkhortisan\AppData\Roaming\Anki2\Khonkhortisan\collection.media\_global.html`
injectFile `<_io.TextIOWrapper name='C:/Users/Khonkhortisan/AppData/Roaming/Anki2/Khonkhortisan/collection.media/_global.html' mode='r' encoding='utf-8'>`
_ `C:\Users\Khonkhortisan\AppData\Roaming\Anki2\Khonkhortisan\collection\_global`
ext `html`